### PR TITLE
Add `db stats` command

### DIFF
--- a/backend/internal/cmd/mf/db/db.go
+++ b/backend/internal/cmd/mf/db/db.go
@@ -8,6 +8,7 @@ type (
 	// Options is the collection of options for the `db` command and its sub command.
 	Options struct {
 		ImportOption *ImportOption
+		StatsOption  *StatsOption
 	}
 )
 
@@ -21,6 +22,7 @@ func NewCmdDB(o *Options) *cobra.Command {
 
 	// TODO: Add delete command
 	cmd.AddCommand(NewCmdDBImport(o.ImportOption))
+	cmd.AddCommand(NewCmdDBStats(o.StatsOption))
 
 	return cmd
 }

--- a/backend/internal/cmd/mf/db/db_stats.go
+++ b/backend/internal/cmd/mf/db/db_stats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/spf13/cobra"
@@ -60,7 +61,7 @@ func (o *StatsOption) Run() error {
 	transaction := database.NewTransaction(db)
 	statsRepo := database.NewStatsRepository(transaction)
 
-	u := usecase.NewStatsMoneyForwardRecords(transaction, statsRepo)
+	u := usecase.NewStatsMoneyForwardRecords(transaction, statsRepo, os.Stdout)
 	args := &usecase.StatsMoneyForwardRecordsArgs{
 		Year: o.year,
 	}

--- a/backend/internal/cmd/mf/db/db_stats.go
+++ b/backend/internal/cmd/mf/db/db_stats.go
@@ -6,14 +6,12 @@ import (
 	"fmt"
 	"os"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "github.com/mattn/go-sqlite3" // support `sqlite3` driver
 	"github.com/spf13/cobra"
 
 	"github.com/takatoshiono/kakeibo/backend/internal/repository/database"
 	"github.com/takatoshiono/kakeibo/backend/internal/usecase"
 )
-
-// support `sqlite3` driver
 
 // NewCmdDBStats creates the `db stats` command.
 func NewCmdDBStats(o *StatsOption) *cobra.Command {

--- a/backend/internal/cmd/mf/db/db_stats.go
+++ b/backend/internal/cmd/mf/db/db_stats.go
@@ -1,0 +1,73 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/spf13/cobra"
+
+	"github.com/takatoshiono/kakeibo/backend/internal/repository/database"
+	"github.com/takatoshiono/kakeibo/backend/internal/usecase"
+)
+
+// support `sqlite3` driver
+
+// NewCmdDBStats creates the `db stats` command.
+func NewCmdDBStats(o *StatsOption) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stats",
+		Short: "Get statistics",
+		Long:  `This command get statistics`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			return o.Run()
+		},
+	}
+
+	cmd.Flags().StringVarP(&o.queryName, "query", "q", "", "stats query name")
+	cmd.Flags().IntVarP(&o.year, "year", "y", 0, "year")
+
+	return cmd
+}
+
+// StatsOption is the option for the `db stats` command.
+type StatsOption struct {
+	DriverName string
+	DSN        string
+	queryName  string
+	year       int
+}
+
+// Validate checks options.
+func (o *StatsOption) Validate() error {
+	if o.queryName == "" {
+		return fmt.Errorf("query name must not be empty")
+	}
+	return nil
+}
+
+// Run executes the `db stats` command.
+func (o *StatsOption) Run() error {
+	db, err := sql.Open(o.DriverName, o.DSN)
+	if err != nil {
+		return fmt.Errorf("failed to open: %w", err)
+	}
+	defer db.Close()
+	transaction := database.NewTransaction(db)
+	statsRepo := database.NewStatsRepository(transaction)
+
+	u := usecase.NewStatsMoneyForwardRecords(transaction, statsRepo)
+	args := &usecase.StatsMoneyForwardRecordsArgs{
+		Year: o.year,
+	}
+	ctx := context.Background()
+	if err := u.Execute(ctx, o.queryName, args); err != nil {
+		return fmt.Errorf("failed to execute: %w", err)
+	}
+
+	return nil
+}

--- a/backend/internal/cmd/mf/root.go
+++ b/backend/internal/cmd/mf/root.go
@@ -61,6 +61,10 @@ func NewCmd(o *Option) *cobra.Command {
 				DriverName: o.DriverName,
 				DSN:        o.DSN,
 			},
+			StatsOption: &db.StatsOption{
+				DriverName: o.DriverName,
+				DSN:        o.DSN,
+			},
 		},
 	))
 	cmd.AddCommand(csv.NewCmdCSV(

--- a/backend/internal/domain/stats.go
+++ b/backend/internal/domain/stats.go
@@ -1,0 +1,11 @@
+package domain
+
+import (
+	"time"
+)
+
+type AmountExpendedByMonth struct {
+	Year   int
+	Month  time.Month
+	Amount int
+}

--- a/backend/internal/repository/database/stats_repository.go
+++ b/backend/internal/repository/database/stats_repository.go
@@ -1,0 +1,68 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/takatoshiono/kakeibo/backend/internal/domain"
+)
+
+// StatsRepository is a database repository for statistics.
+type StatsRepository struct {
+	transaction *Transaction
+}
+
+// NewStatsRepository returns a new StatsRepository.
+func NewStatsRepository(transaction *Transaction) *StatsRepository {
+	return &StatsRepository{
+		transaction: transaction,
+	}
+}
+
+// FindAmountExpendedByMonth finds amount expended group by month for given year.
+func (repo *StatsRepository) FindAmountExpendedByMonth(ctx context.Context, year int) ([]*domain.AmountExpendedByMonth, error) {
+	db := repo.transaction.getDB()
+
+	const findQuery = `
+SELECT strftime('%m',recorded_on) m, abs(sum(amount)) a
+FROM money_forward_records
+WHERE recorded_on BETWEEN ? AND ?
+AND amount < 0
+GROUP BY m`
+	findArgs := []interface{}{
+		fmt.Sprintf("%04d-01-01", year),
+		fmt.Sprintf("%04d-12-31", year),
+	}
+
+	rows, err := db.QueryContext(ctx, findQuery, findArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query: %w", err)
+	}
+	defer rows.Close()
+
+	out := []*domain.AmountExpendedByMonth{}
+	for rows.Next() {
+		var monthStr string
+		var amount int
+		if err := rows.Scan(&monthStr, &amount); err != nil {
+			return nil, fmt.Errorf("failed to scan: %w", err)
+		}
+		month, err := strconv.Atoi(monthStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert month string to int: %w", err)
+		}
+		out = append(out, &domain.AmountExpendedByMonth{
+			Year:   year,
+			Month:  time.Month(month),
+			Amount: amount,
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate rows: %w", err)
+	}
+
+	return out, nil
+}

--- a/backend/internal/testutil/db.go
+++ b/backend/internal/testutil/db.go
@@ -1,8 +1,10 @@
 package testutil
 
 import (
+	"context"
 	"database/sql"
 	"sync"
+	"testing"
 
 	"github.com/takatoshiono/kakeibo/backend/internal/config"
 )
@@ -31,4 +33,12 @@ func MustGetDB() *sql.DB {
 		panic("failed to open database: " + err.Error())
 	}
 	return db
+}
+
+// TruncateTable deletes all records in given table.
+func TruncateTable(ctx context.Context, t *testing.T, db *sql.DB, tableName string) {
+	t.Helper()
+	if _, err := db.Exec(`DELETE FROM ` + tableName); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/backend/internal/testutil/stdout.go
+++ b/backend/internal/testutil/stdout.go
@@ -1,0 +1,35 @@
+package testutil
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+// CaptureStdout captures standard output during fn() and return it.
+func CaptureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	orig := os.Stdout
+	os.Stdout = w
+
+	fn()
+
+	os.Stdout = orig
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+
+	return buf.String()
+}

--- a/backend/internal/usecase/interface.go
+++ b/backend/internal/usecase/interface.go
@@ -42,3 +42,8 @@ type MasterRepository interface {
 type MoneyForwardRepository interface {
 	CreateOrUpdateRecord(ctx context.Context, record *domain.MoneyForwardRecord) error
 }
+
+// StatsRepository is a interface of StatsRepository.
+type StatsRepository interface {
+	FindAmountExpendedByMonth(ctx context.Context, year int) ([]*domain.AmountExpendedByMonth, error)
+}

--- a/backend/internal/usecase/stats_money_forward_records.go
+++ b/backend/internal/usecase/stats_money_forward_records.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
-	"os"
+	"io"
 	"strconv"
 )
 
@@ -17,13 +17,15 @@ type StatsMoneyForwardRecordsArgs struct {
 type StatsMoneyForwardRecords struct {
 	transaction Transaction
 	statsRepo   StatsRepository
+	w           io.Writer
 }
 
 // NewStatsMoneyForwardRecords returns a new StatsMoneyForwardRecords usecase.
-func NewStatsMoneyForwardRecords(transaction Transaction, statsRepo StatsRepository) *StatsMoneyForwardRecords {
+func NewStatsMoneyForwardRecords(transaction Transaction, statsRepo StatsRepository, w io.Writer) *StatsMoneyForwardRecords {
 	return &StatsMoneyForwardRecords{
 		transaction: transaction,
 		statsRepo:   statsRepo,
+		w:           w,
 	}
 }
 
@@ -52,7 +54,7 @@ func (u *StatsMoneyForwardRecords) Execute(ctx context.Context, queryName string
 }
 
 func (u *StatsMoneyForwardRecords) outputCSV(records [][]string) error {
-	w := csv.NewWriter(os.Stdout)
+	w := csv.NewWriter(u.w)
 	for _, record := range records {
 		if err := w.Write(record); err != nil {
 			return fmt.Errorf("failed to write: %w", err)

--- a/backend/internal/usecase/stats_money_forward_records.go
+++ b/backend/internal/usecase/stats_money_forward_records.go
@@ -1,0 +1,66 @@
+package usecase
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// StatsMoneyForwardRecordsArgs holds arguments to execute StatsMoneyForwardRecords.
+type StatsMoneyForwardRecordsArgs struct {
+	Year int
+}
+
+// StatsMoneyForwardRecords is a usecase for money forward records.
+type StatsMoneyForwardRecords struct {
+	transaction Transaction
+	statsRepo   StatsRepository
+}
+
+// NewStatsMoneyForwardRecords returns a new StatsMoneyForwardRecords usecase.
+func NewStatsMoneyForwardRecords(transaction Transaction, statsRepo StatsRepository) *StatsMoneyForwardRecords {
+	return &StatsMoneyForwardRecords{
+		transaction: transaction,
+		statsRepo:   statsRepo,
+	}
+}
+
+// Execute executes the usecase.
+func (u *StatsMoneyForwardRecords) Execute(ctx context.Context, queryName string, args *StatsMoneyForwardRecordsArgs) error {
+	out := [][]string{}
+	switch queryName {
+	case "AmountExpendedByMonth":
+		res, err := u.statsRepo.FindAmountExpendedByMonth(ctx, args.Year)
+		if err != nil {
+			return fmt.Errorf("failed to find amount expended by month: %w", err)
+		}
+		for _, r := range res {
+			out = append(out, []string{
+				strconv.Itoa(int(r.Month)),
+				strconv.Itoa(r.Amount),
+			})
+		}
+		if err := u.outputCSV(out); err != nil {
+			return fmt.Errorf("failed to output csv: %w", err)
+		}
+	default:
+		return fmt.Errorf("unknown query name '%v'", queryName)
+	}
+	return nil
+}
+
+func (u *StatsMoneyForwardRecords) outputCSV(records [][]string) error {
+	w := csv.NewWriter(os.Stdout)
+	for _, record := range records {
+		if err := w.Write(record); err != nil {
+			return fmt.Errorf("failed to write: %w", err)
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return fmt.Errorf("failed to flush: %w", err)
+	}
+	return nil
+}

--- a/backend/test/e2e/cmd_mf_db_import_test.go
+++ b/backend/test/e2e/cmd_mf_db_import_test.go
@@ -16,12 +16,7 @@ import (
 	"github.com/takatoshiono/kakeibo/backend/internal/testutil"
 )
 
-const (
-	filenameMF = "../../testdata/mf/mf.csv"
-)
-
 func TestCmdMFDBImport(t *testing.T) {
-	// TODO: テストデータを消す
 	// TODO: CreateのケースとUpdateのケースを明示的にテストする
 	c := testutil.MustGetConfig()
 	opt := &mf.Option{
@@ -89,6 +84,12 @@ func TestCmdMFDBImport(t *testing.T) {
 	masterRepo := database.NewMasterRepository(transaction)
 	mfRepo := database.NewMoneyForwardRepository(transaction)
 	ctx := context.Background()
+
+	defer func() {
+		testutil.TruncateTable(ctx, t, db, "money_forward_records")
+		testutil.TruncateTable(ctx, t, db, "categories")
+		testutil.TruncateTable(ctx, t, db, "sources")
+	}()
 
 	for _, want := range expected {
 		s, err := masterRepo.FindSourceByName(ctx, want.SourceName)

--- a/backend/test/e2e/cmd_mf_db_stats_test.go
+++ b/backend/test/e2e/cmd_mf_db_stats_test.go
@@ -1,0 +1,49 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/takatoshiono/kakeibo/backend/internal/cmd/mf"
+	"github.com/takatoshiono/kakeibo/backend/internal/testutil"
+)
+
+func TestCmdMFDBStats_AmountExpendedByMonth(t *testing.T) {
+	c := testutil.MustGetConfig()
+	opt := &mf.Option{
+		DriverName: c.TestDBDriverName,
+		DSN:        c.TestDBDSN,
+	}
+	cmd := mf.NewCmd(opt)
+
+	// Setup
+	cmd.SetArgs([]string{"db", "import", "--file", filenameMF})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		ctx := context.Background()
+		db := testutil.MustGetDB()
+		testutil.TruncateTable(ctx, t, db, "money_forward_records")
+		testutil.TruncateTable(ctx, t, db, "categories")
+		testutil.TruncateTable(ctx, t, db, "sources")
+	}()
+
+	// Run
+	got := testutil.CaptureStdout(t, func() {
+		cmd.SetArgs([]string{"db", "stats", "--query", "AmountExpendedByMonth", "--year", "2020"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Confirm
+	want := "7,2801\n"
+
+	if d := cmp.Diff(want, got); d != "" {
+		t.Error(d)
+	}
+}

--- a/backend/test/e2e/const.go
+++ b/backend/test/e2e/const.go
@@ -1,0 +1,5 @@
+package e2e
+
+const (
+	filenameMF = "../../testdata/mf/mf.csv"
+)


### PR DESCRIPTION
The `db stats` command execute stats query.

Supported query:
- `AmountExpendedByMonth`
  - Get amount expended in each month of the year which is specified in `--year` option.